### PR TITLE
chore: add SB story for heading

### DIFF
--- a/src/stories/Heading.stories.js
+++ b/src/stories/Heading.stories.js
@@ -1,0 +1,23 @@
+import Heading from '../app/components/heading';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Heading',
+  component: Heading,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
+    layout: 'centered',
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
+  tags: ['autodocs'],
+};
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+export const Base = {
+  args: {
+    className: "test",
+    children: 'coffee',
+    level: 4
+  },
+};
+


### PR DESCRIPTION
## context
Figuring out how to create a new SB component, beginning with a header
 
## work done

- Setup local environment using VS code, terminal, github and Storybook

- Created a new header component referencing the header.js file for required prop types. Used Button.stories.js (out-of-the-box component) as a template for Header.stories.js 

## manual testing instructions

- Run storybook script in terminal:  npm run storybook 

- Used local server for component testing:  http://localhost:6006/

## gotchas/what I learned

- How to set up working with SB on my local machine and begin building components. 

- Importing heading.js - @import the component name isn't wrapped in {} 