### PR TITLE
chore: Add fonts

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,12 +1,17 @@
 import './globals.css'
-import { Inter } from 'next/font/google'
+import { Roboto } from 'next/font/google'
 import Image from 'next/image'
 import cdLogoHorizontal from '/public/cdLogoHorizontal.png'
 import cdLogoSquare from '/public/cdLogoSquare.png'
 import IconPhone from './components/icon-phone'
 import IconEnvelope from './components/icon-envelope'
 
-const inter = Inter({ subsets: ['latin'] })
+const roboto = Roboto({
+  weight: ['400', '500', '700'],
+  display: 'swap',
+  variable: '--font-roboto',
+  subsets: ['latin']
+})
 
 export const metadata = {
   title: 'Citydoor',
@@ -14,8 +19,8 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang='en'>
-      <body className={`${inter.className} p-4 cd-desktop:p-0 flex flex-col items-stretch h-screen`}>
+    <html lang='en' className={`${roboto.variable}`}>
+      <body className='flex flex-col items-stretch h-screen p-4 cd-desktop:p-0'>
         <header className='mb-10 cd-desktop:mb-8'>
           <div className='flex flex-col items-center gap-2 px-4 py-4 mb-10 cd-desktop:gap-6 cd-desktop:px-20 cd-desktop:flex-row bg-cd-tertiary cd-desktop:py-5 cd-desktop:mb-6'>
             <div className='flex items-center gap-1'>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,9 @@ module.exports = {
         'cd-secondary': '#90AFC5',
         'cd-white': '#FFFFFF'
       },
+      fontFamily: {
+        sans: ['var(--font-roboto)']
+      },
       screens: {
         'cd-desktop': '1469px'
       }


### PR DESCRIPTION
## This PR...
Adds the Roboto font specified in the Figma.

Caveat: The figma references a 600 weight but Google fonts does not provide a 600 weight, so we are using a 500 weight instead. The browser should still show a semi-bold that looks fairly close to the Figma.

## What I did...

- Removed the "Inter" font from layouts
- Added "Roboto" and specified some additional parameters we will need (note I also made it a CSS variable, for use elsewhere)
- Added the CSS variable to the html element so we can use it anywhere
- Used the CSS variable in TW so that TW will use Robot as the default for sans serif fonts.

## How to test...

1. serve the site locally or go to the preview site linkedin the PR
2. Inspect the dev tools or use an extension like [FontsNinja](https://chromewebstore.google.com/detail/fonts-ninja/eljapbgkmlngdpckoiiibecpemleclhh) (Chrome) to check all text on the page
- Expect that all fonts are using Roboto

## I learned...
[How NextJS handles fonts](https://nextjs.org/docs/app/building-your-application/optimizing/fonts). Note that this isn't the same in all frameworks, and that NextJS does a lot of things for devs out of the box.